### PR TITLE
add: emailかpasswordの間違いを指摘するerrorを追加

### DIFF
--- a/pkg/clients/edstem/errors.go
+++ b/pkg/clients/edstem/errors.go
@@ -8,8 +8,8 @@ type ErrEmailOrPasswdWrong struct {
 	Email string
 }
 
-func (e *ErrEmailOrPasswdWrong) Error() error {
-	return fmt.Errorf(fmt.Sprintf("The email or password is wrong for Edstem account: email: %s\n", e.Email))
+func (e *ErrEmailOrPasswdWrong) Error() string {
+	return fmt.Sprintf("The email or password is wrong for Edstem account: email: %s\n", e.Email)
 }
 
 func NewErrEmailOrPasswdWrong(email string) *ErrEmailOrPasswdWrong {

--- a/pkg/clients/edstem/errors.go
+++ b/pkg/clients/edstem/errors.go
@@ -1,0 +1,19 @@
+package edstem
+
+import (
+	"fmt"
+)
+
+type ErrEmailOrPasswdWrong struct {
+	Email string
+}
+
+func (e *ErrEmailOrPasswdWrong) Error() error {
+	return fmt.Errorf(fmt.Sprintf("The email or password is wrong for Edstem account: email: %s\n", e.Email))
+}
+
+func NewErrEmailOrPasswdWrong(email string) *ErrEmailOrPasswdWrong {
+	return &ErrEmailOrPasswdWrong{
+		Email: email,
+	}
+}

--- a/pkg/clients/edstem/login_test.go
+++ b/pkg/clients/edstem/login_test.go
@@ -36,3 +36,20 @@ func TestEdstam(t *testing.T) {
 	}
 	fmt.Println(announcement)
 }
+
+func TestEdstemWrongPasswd(t *testing.T) {
+	c := edstem.NewClient()
+	err := c.Login(email, password+"wrong_password")
+
+	switch err.(type) {
+	case *edstem.ErrEmailOrPasswdWrong:
+		e := err.(*edstem.ErrEmailOrPasswdWrong) // 型をキャスト
+		if e.Email != email {
+			t.Errorf("err.Email: Expected %s, but got %s", email, e.Email)
+		}
+		break
+
+	default:
+		t.Errorf("Expected *edstem.ErrEmailOrPasswdWrong, but got %v", err)
+	}
+}

--- a/pkg/clients/edstem/login_test.go
+++ b/pkg/clients/edstem/login_test.go
@@ -46,7 +46,6 @@ func TestEdstemWrongPasswd(t *testing.T) {
 		if err.Email != email {
 			t.Errorf("err.Email: Expected %s, but got %s", email, err.Email)
 		}
-		break
 
 	default:
 		t.Errorf("Expected *edstem.ErrEmailOrPasswdWrong, but got %v", err)

--- a/pkg/clients/edstem/login_test.go
+++ b/pkg/clients/edstem/login_test.go
@@ -41,11 +41,10 @@ func TestEdstemWrongPasswd(t *testing.T) {
 	c := edstem.NewClient()
 	err := c.Login(email, password+"wrong_password")
 
-	switch err.(type) {
+	switch err := err.(type) {
 	case *edstem.ErrEmailOrPasswdWrong:
-		e := err.(*edstem.ErrEmailOrPasswdWrong) // 型をキャスト
-		if e.Email != email {
-			t.Errorf("err.Email: Expected %s, but got %s", email, e.Email)
+		if err.Email != email {
+			t.Errorf("err.Email: Expected %s, but got %s", email, err.Email)
 		}
 		break
 

--- a/pkg/clients/edstem/token.go
+++ b/pkg/clients/edstem/token.go
@@ -3,7 +3,6 @@ package edstem
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 )
@@ -18,7 +17,7 @@ func (c *Client) getToken(email, password string) (string, error) {
 		return "", err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("response status was %d(except %d)", resp.StatusCode, http.StatusOK)
+		return "", NewErrEmailOrPasswdWrong(email).Error()
 	}
 
 	defer resp.Body.Close()

--- a/pkg/clients/edstem/token.go
+++ b/pkg/clients/edstem/token.go
@@ -17,7 +17,7 @@ func (c *Client) getToken(email, password string) (string, error) {
 		return "", err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", NewErrEmailOrPasswdWrong(email).Error()
+		return "", NewErrEmailOrPasswdWrong(email)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
## Issueへのリンク
[#19](https://github.com/arumakan1727/taskrader/issues/19)

## 確認してほしいこと
- emailかpasswordを間違えたときに、わかるようにerrorが返ってきているかどうか。

## 注意点・気になっている点・不安な点 (もしあれば)
- teamsのような実装方法ではなくgetTokenでStatusCodeが200以外ならemailかpasswordが間違えていると仮定の下で実装している。本当にそれが正しいのかどうかがわからない。
